### PR TITLE
Add default summarize_function to percentiles

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -184,6 +184,13 @@ var timer_gauge_pct = function(timer_name, values, pct, suffix)
   var thresholdIndex = Math.round(((100 - pct) / 100) * values.length);
   var numInThreshold = values.length - thresholdIndex;
 
+  // Due to the weird way statsd defines 'percentile', they report all timings as
+  // "100th percentiles".  We want to treat the base metric the same way we have
+  // in the past (with the default 'average' summary function), but all of the
+  // other generated "percentiles" should be set to 'max' to match up with the
+  // statistical definition of a percentile (a single value and not a range).
+  var summarizeFunction = (pct === 100) ? "average" : "max";
+
   if (numInThreshold <= 0) {
     return null;
   }
@@ -211,7 +218,10 @@ var timer_gauge_pct = function(timer_name, values, pct, suffix)
     sum: sum,
     sum_squares: sumOfSquares,
     min: min,
-    max: max
+    max: max,
+    attributes: {
+      summarize_function: summarizeFunction
+    }
   };
 }
 


### PR DESCRIPTION
Using the API's syntax for [updating metrics](http://api-docs-archive.librato.com/?shell#update-a-metric).

The `attributes` key is actually meant for PUTs, but the [Librato metric POST API](http://api-docs-archive.librato.com/?shell#measurement-parameters) specifies the following:

> NOTE: The optional parameters listed in the metrics PUT operation can be used with POST operations, but they will be ignored if the metric already exists. To update existing metrics, please use the PUT operation.

So, what we should do is as follows:
1. Update our existing 90th percentile metrics to have `attributes: { summarize_function: "max" }` via PUT.
2. Get this backend up and running.
3. Ship the configuration change that starts recording 50, 90, 95 and 99 percentiles.